### PR TITLE
fix: circular import in __init__.py for spotisub

### DIFF
--- a/spotisub/__init__.py
+++ b/spotisub/__init__.py
@@ -1,5 +1,4 @@
 """Spotisub init module"""
-from spotisub import routes, classes, errors
 import logging
 import os
 from logging.handlers import RotatingFileHandler
@@ -42,3 +41,5 @@ bootstrap = Bootstrap(spotisub)
 configuration_db = SQLAlchemy(spotisub)
 login = LoginManager(spotisub)
 login.login_view = 'login'
+
+from spotisub import routes, classes, errors


### PR DESCRIPTION
Version 0.3.5 gives the following error:

```
Exception in worker process
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/arbiter.py", line 608, in spawn_worker
    worker.init_process()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/workers/geventlet.py", line 142, in init_process
    super().init_process()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/workers/base.py", line 135, in init_process
    self.load_wsgi()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/workers/base.py", line 147, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
    return self.load_wsgiapp()
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/home/user/.local/lib/python3.10/site-packages/gunicorn/util.py", line 370, in import_app
    mod = importlib.import_module(module)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/user/spotisub/spotisub/__init__.py", line 2, in <module>
    from spotisub import routes, classes, errors
  File "/home/user/spotisub/spotisub/routes.py", line 33, in <module>
    from spotisub import spotisub
ImportError: cannot import name 'spotisub' from partially initialized module 'spotisub' (most likely due to a circular import) (/home/user/spotisub/spotisub/__init__.py)

```
This error occurs most likely because routes.py imports from the not fully initialized spotisub module. Temporarily this circular import error can be  fixed by moving the imports to the bottom to ensure full module init before importing anywhere else (like release 0.3.4). 
In the future, this should be rewritten to either factor out the app/route components or use local imports anywhere but in init, will work on it next :)
Thanks for your work!