### PR TITLE
fix: adapt playlist import to Spotify's February 2026 /items change

### DIFF
--- a/spotisub/generator.py
+++ b/spotisub/generator.py
@@ -9,6 +9,7 @@ import math
 import threading
 from datetime import datetime
 from datetime import timedelta
+import spotipy
 from flask_apscheduler import APScheduler
 from spotisub import spotisub
 from spotisub import constants
@@ -493,9 +494,14 @@ def get_user_playlists_run(uuid, offset=0):
                 logging.info(
                     '(%s) Importing playlist: %s', str(
                         threading.current_thread().ident), item['name'])
-                result = dict({'tracks': []})
-                result = get_playlist_tracks(item, result)
-                subsonic_helper.write_playlist(sp, playlist_info, result)
+                try:
+                    result = dict({'tracks': []})
+                    result = get_playlist_tracks(item, result)
+                    subsonic_helper.write_playlist(sp, playlist_info, result)
+                except spotipy.SpotifyException as e:
+                    logging.warning(
+                        '(%s) Skipping playlist %s: %s', str(
+                            threading.current_thread().ident), item['name'], e)
 
         if len(playlist_result['items']) != 0:
             get_user_playlists_run(uuid, offset=offset + 50)
@@ -561,11 +567,12 @@ def get_playlist_tracks(item, result, offset_tracks=0):
     response_tracks = sp.playlist_items(
         item['id'],
         offset=offset_tracks,
-        fields='items.track.id,items.track.name,items.track.artists,items.track.type,total',
+        fields='items.item.id,items.item.name,items.item.artists,items.item.type,total',
         limit=50,
         additional_types=['track'])
     for track_item in response_tracks['items']:
-        track = track_item['track']
+        # Feb 2026 API: the track moved to the "item" key ("track" is deprecated)
+        track = track_item.get('item')
 
         if track is None:
             continue


### PR DESCRIPTION
## Problem

Since Spotify's [February 2026 dev-mode Web API changes](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide), playlists are imported but never populated. `spotipy` now calls the replacement `GET /v1/playlists/{id}/items` endpoint, but `get_playlist_tracks` and `get_user_playlists_run` were never updated for two changes it introduces.

**1. The track is now under `item`, not `track`.**
On `/items` each entry exposes the track under `item`; the `track` key is [deprecated](https://developer.spotify.com/documentation/web-api/reference/get-playlists-items). With `fields=items.track.*` the items come back empty, so `track_item['track']` raises a `KeyError`:

```
INFO  Importing playlist: Awesome Lofi
ERROR Error during reimport: 'track'
```

**2. One inaccessible playlist aborts the entire reimport.**
Playlists the user does not own return `403` on `/items`, and the per-playlist loop has no error handling, so the first failure stops the run and leaves every remaining playlist empty:

```
ERROR HTTP Error for GET to .../v1/playlists/{id}/items ... returned 403 due to Forbidden
ERROR Error during reimport: http status: 403, code: -1 - ... Forbidden
```

## Fix

Both changes are in `spotisub/generator.py`:

- **`get_playlist_tracks`** – read the track from `item` and request `items.item.*` fields.
- **`get_user_playlists_run`** – wrap each playlist's import in `try/except spotipy.SpotifyException`, logging a warning and continuing, so an inaccessible playlist is skipped instead of aborting the run.

Tested on an account with a mix of owned and followed playlists: owned playlists import correctly again, and un-owned ones are skipped with a warning instead of killing the reimport.

Fixes #100
